### PR TITLE
Allow passing args with as additional arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,12 @@ to support online compilation of user code in a safe sandbox.
 
 Run the docker container passing the base64 source as command line parameter:
 
-	> bsource=$(echo 'void main() { import std.conv; std.stdio; writefln("Hello World, %s", 42.to!int); }' | base64 -w0)
-	> docker run --rm dlangtour/core-dreg $bsource
+```bash
+bsource=$(echo 'void main() { import std.conv; std.stdio; writefln("Hello World, %s", 42.to!int); }' | base64 -w0)
+docker run --rm dlangtour/core-dreg $bsource
+```
+
+It returns:
 
 ```
 Up to      2.062  : Failure with output:
@@ -25,6 +29,37 @@ onlineapp.d(1): Error: undefined identifier 'to'
 -----
 
 Since      2.063  : Success with output: Hello World, 2
+```
+
+### Bash aliases
+
+As this Docker images is intended for [run.dlang.io](https://run.dlang.io), it
+base64-encodes the input. As this is a bit bulky, for local usage, this wrapper
+is recommended.
+For example, create this file `dreg` and add it to your `PATH`:
+
+```bash
+#!/bin/bash
+docker run --rm dlangtour/core-dreg $(echo "$1" | base64 -w0) ${@:2}
+```
+
+Usage is as follows:
+
+```
+dreg "import std.experimental.allocator;" -c
+```
+
+it returns:
+
+```
+Up to      2.068.2: Failure with output:
+-----
+onlineapp.d(1): Error: module allocator is in file 'std/experimental/allocator.d' which cannot be read
+import path[0] = /path/to/dmd/dmd2/linux/bin64/../../src/phobos
+import path[1] = /path/to/dmd/dmd2/linux/bin64/../../src/druntime/import
+-----
+
+Since      2.069.2: Success and no output
 ```
 
 ## Docker image

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,15 @@ set -u
 set -o pipefail
 
 cd /sandbox
-echo "$*" | base64 -d > onlineapp.d
+echo "$1" | base64 -d > onlineapp.d
 
-exec timeout -s KILL ${TIMEOUT:-60} dreg dmd -run onlineapp.d | tail -n100
+args=${DOCKER_FLAGS:-""}
+# fallback to $2
+args=${args:-${@:2}}
+compiler="dmd"
+
+if [[ $args =~ .*-c.* ]] ; then
+    exec timeout -s KILL ${TIMEOUT:-30} dreg "${compiler}" $args onlineapp.d | tail -n100
+elif [ -z ${2:-""} ] ; then
+    exec timeout -s KILL ${TIMEOUT:-30} dreg "${compiler}" $args -g -run onlineapp.d | tail -n10000
+fi

--- a/test.sh
+++ b/test.sh
@@ -13,7 +13,17 @@ trap 'err_report $LINENO' ERR
 
 source='void main() { import std.experimental.allocator; }'
 bsource=$(echo $source | base64 -w0)
-docker run --rm $dockerId $bsource | grep -zq "Failure.*with output:.*Since.*2.069.2"
+docker run --rm $dockerId $bsource| grep -zq "Failure.*with output:.*Since.*Success"
+
+# test custom args
+source='import std.experimental.allocator;'
+bsource=$(echo $source | base64 -w0)
+docker run --rm $dockerId $bsource -c | grep -zq "Failure.*with output:.*Since.*Success"
+
+# test docker flags
+source='import std.experimental.allocator;'
+bsource=$(echo $source | base64 -w0)
+DOCKER_FLAGS="-c" docker run -e DOCKER_FLAGS --rm $dockerId $bsource | grep -zq "Failure.*with output:.*Since.*Success"
 
 source='void main() { import std.stdio; }'
 bsource=$(echo $source | base64 -w0)


### PR DESCRIPTION
This makes it easy to do regression testing locally, e.g.

```bash
dreg "import std.experimental.allocator;" -c
```