### PR TITLE
Add support for multiple files using HAR

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "ae"]
 	path = ae
 	url = https://github.com/CyberShadow/ae
+[submodule "har"]
+	path = har
+	url = https://github.com/marler8997/har

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get install --no-install-recommends -y \
 
 COPY ae /work/build/ae
 COPY misc /work/build/misc
+COPY har /work/build/har
 COPY Makefile *.patch /work/build/
 
 RUN . /work/ldc*/activate \
@@ -32,6 +33,7 @@ RUN . /work/ldc*/activate \
  && mkdir -p /dlang \
  && cp /work/build/bin/dver /dlang/dver \
  && cp /work/build/bin/dreg /dlang/dreg \
+ && cp /work/build/bin/har /dlang/har \
 # If required by further steps
 #  && mv /work/ldc* /ldc \
 #  && chmod a=+rx /ldc \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: bin/dver bin/dreg
+all: bin/dver bin/dreg bin/har
 
 TAG=core-dreg:local
 
@@ -24,6 +24,9 @@ bin/dreg: misc/dreg.d misc/.patched
 
 bin/list_tags: list_tags.d
 	rdmd --build-only -of$@ $<
+
+bin/har: har/harmain.d
+	rdmd --build-only -of=$@ -Ihar/src $(EXTRA_DFLAGS) $<
 
 clean:
 	rm -rf bin

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,8 +12,20 @@ args=${DOCKER_FLAGS:-""}
 args=${args:-${@:2}}
 compiler="dmd"
 
+if grep -q "^--- .*d" onlineapp.d > /dev/null 2>&1  ; then
+    mv onlineapp.d onlineapp.har
+    har_files="$(har --dir=$PWD "onlineapp.har")"
+
+    files=($(echo "$har_files" | grep "[.]d$" || echo ""))
+else
+    files=("onlineapp.d")
+fi
+
 if [[ $args =~ .*-c.* ]] ; then
-    exec timeout -s KILL ${TIMEOUT:-60} dreg "${compiler}" $args onlineapp.d | tail -n100
+    exec timeout -s KILL ${TIMEOUT:-60} dreg "${compiler}" $args ${files[@]} | tail -n100
 elif [ -z ${2:-""} ] ; then
-    exec timeout -s KILL ${TIMEOUT:-60} dreg "${compiler}" $args -g -run onlineapp.d | tail -n10000
+    N="${#files[@]}"
+    add="${files[@]:1:$N}"
+    entry="${files[0]}"
+    exec timeout -s KILL ${TIMEOUT:-60} dreg "${compiler}" $args -g $add -run $entry | tail -n10000
 fi

--- a/test.sh
+++ b/test.sh
@@ -28,3 +28,33 @@ DOCKER_FLAGS="-c" docker run -e DOCKER_FLAGS --rm $dockerId $bsource | grep -zq 
 source='void main() { import std.stdio; }'
 bsource=$(echo $source | base64 -w0)
 [ $(docker run --rm $dockerId $bsource | wc -l) -eq 1 ]
+
+# Multiple files passed via HAR
+bsource=$(base64 -w0 <<EOF
+--- main.d
+
+import lib;
+
+void main()
+{
+    foo();
+}
+
+--- lib.d
+
+import std.stdio;
+
+static immutable string greeting = import("data.txt");
+
+void foo()
+{
+    writeln(greeting);
+}
+
+--- data.txt
+Hello, World!
+EOF
+)
+
+DOCKER_FLAGS="-J."    docker run -e DOCKER_FLAGS --rm $dockerId $bsource | grep -zq "Hello, World!"
+DOCKER_FLAGS="-J. -c" docker run -e DOCKER_FLAGS --rm $dockerId $bsource


### PR DESCRIPTION
Enables the generated image (used by "Run all compilers" on `run.dlang.org`) to accept multiple files. This was already supported for the other options.