### PR TITLE
Build required tools in Docker

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -22,16 +22,6 @@ jobs:
         with:
           submodules: true
 
-      # Fetch host compiler
-      - name: Install host LDC
-        uses: dlang-community/setup-dlang@v1
-        with:
-          compiler: ldc-latest
-
-      # Run make to build dreg and dver which are used in the Dockerfile
-      - name: Build dreg and dver
-        run: make all
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:16.04
+# Base image providing the basic dependencies
+# extended by the builder and final image
+FROM ubuntu:16.04 as base
 
 MAINTAINER "Sebastian Wilzbach <seb@wilzba.ch>"
 
@@ -7,8 +9,13 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 	ca-certificates \
 	curl \
 	gcc \
+	libc-dev
+
+# Temporary environment to build the tools
+FROM base as builder
+
+RUN apt-get install --no-install-recommends -y \
 	gnupg \
-	libc-dev \
 	libxml2 \
 	make \
 	patch \
@@ -28,12 +35,14 @@ RUN . /work/ldc*/activate \
 # If required by further steps
 #  && mv /work/ldc* /ldc \
 #  && chmod a=+rx /ldc \
- && rm -rf /work \
- && apt-get remove -y \
-	make \
-	patch
+ && rm -rf /work
+
+# Final image providing the collection of different compiler versions
+FROM base as final
 
 # ENV PATH=/ldc/bin:${PATH}
+
+COPY --from=builder /dlang /dlang
 
 RUN for ver in \
 		#2.051 2.052 2.053 2.054 2.055 2.056 2.057 2.058 2.059 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,40 @@ FROM ubuntu:16.04
 
 MAINTAINER "Sebastian Wilzbach <seb@wilzba.ch>"
 
-COPY bin/dver /dlang/dver
-COPY bin/dreg /dlang/dreg
-
 RUN apt-get update && apt-get install --no-install-recommends -y \
-	aria2 libc-dev gcc curl ca-certificates \ 
-	&& for ver in \
+	aria2 \
+	ca-certificates \
+	curl \
+	gcc \
+	gnupg \
+	libc-dev \
+	libxml2 \
+	make \
+	patch \
+	xz-utils \
+ && curl -L -O https://dlang.org/install.sh \
+ && bash install.sh -p /work install ldc-1.26.0
+
+COPY ae /work/build/ae
+COPY misc /work/build/misc
+COPY Makefile *.patch /work/build/
+
+RUN . /work/ldc*/activate \
+ && make -C /work/build \
+ && mkdir -p /dlang \
+ && cp /work/build/bin/dver /dlang/dver \
+ && cp /work/build/bin/dreg /dlang/dreg \
+# If required by further steps
+#  && mv /work/ldc* /ldc \
+#  && chmod a=+rx /ldc \
+ && rm -rf /work \
+ && apt-get remove -y \
+	make \
+	patch
+
+# ENV PATH=/ldc/bin:${PATH}
+
+RUN for ver in \
 		#2.051 2.052 2.053 2.054 2.055 2.056 2.057 2.058 2.059 \
 		2.060 2.061 2.062 2.063 2.064 2.065.0 2.066.0 2.067.1 2.068.2 2.069.2 \
 		2.070.2 2.071.2 2.072.2 2.073.2 2.074.1 2.075.1 2.076.1 2.077.1 2.078.1 2.079.1 \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,13 @@
 all: bin/dver bin/dreg
 
+TAG=core-dreg:local
+
+docker-image:
+	docker build -t $(TAG) .
+
+test: docker-image
+	./test.sh $(TAG)
+
 misc/.patched:
 	cd misc && patch dreg.d < ../dreg.patch
 	cd misc && patch dver.d < ../dver.patch


### PR DESCRIPTION
Importing binaries built on the host risks errors due to mismatched shared libraries.
(e.g. `dver` fails locally due to a mismatched `GLIBC` version) 

CC @PetarKirov 